### PR TITLE
Shrinked NavBar component to the size of the tabs it holds

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -66,9 +66,10 @@ const useStyles = makeStyles((theme) => ({
         fontFamily: `'Work Sans', sans-serif`,
     },
     appbar: {
+        display: 'flex',
         backgroundColor: 'transparent',
         boxShadow: 'none',
-        
+        width: 'auto',
     },
     tab: {
       fontSize: 26,
@@ -81,8 +82,10 @@ const useStyles = makeStyles((theme) => ({
       fontFamily: `'Work Sans', sans-serif`,
     },
     toolbar: {
+      display: 'flex',
       justifyContent: 'flex-end',
       backgroundColor: 'transparent',
+      width: 'auto',
   },
 }));
 


### PR DESCRIPTION
I reduced the size because it would interfere with clicking the different resume viewing modes.
Before, the appbar and toolbar spanned the width of the viewport. 
Now it's only as wide as the group of tabs it holds.